### PR TITLE
Filter for nodes only in status queries

### DIFF
--- a/sh/scenarios/common/itst.sh
+++ b/sh/scenarios/common/itst.sh
@@ -449,7 +449,7 @@ function verify_wasm_inclusion() {
 }
 
 function get_running_node_count {
-    local RUNNING_COUNT=$(nctl-status | grep 'RUNNING' | wc -l)
+    local RUNNING_COUNT=$(nctl-status | grep -Ec 'node-[0-9]+ +RUNNING')
     echo "$RUNNING_COUNT"
 }
 

--- a/sh/utils/infra.sh
+++ b/sh/utils/infra.sh
@@ -401,7 +401,7 @@ function get_process_name_of_node_group()
 #######################################
 function get_count_of_started_nodes()
 {
-    nctl-status | grep -v 'Not started' | wc -l
+    nctl-status | grep -E 'node-[0-9]+' | grep -v 'Not started' | wc -l
 }
 
 


### PR DESCRIPTION
This should fix the asset dump issue, two scripts were counting nodes incorrectly.
I've checked all occurences of `nctl-status |` and these were the only two affected.