### PR TITLE
Fix `upgrade-scenario-01`

### DIFF
--- a/sh/scenarios-upgrades/upgrade_scenario_01.sh
+++ b/sh/scenarios-upgrades/upgrade_scenario_01.sh
@@ -183,22 +183,6 @@ function _step_07()
 
     log_step_upgrades 7 "joining passive nodes"
 
-    log "... submitting auction bids"
-    for NODE_ID in $(seq 1 "$(get_count_of_nodes)")
-    do
-        if [ $(get_node_is_up "$NODE_ID") == false ]; then
-            source "$NCTL/sh/contracts-auction/do_bid.sh" \
-                node="$NODE_ID" \
-                amount="$(get_node_staking_weight "$NODE_ID")" \
-                rate="2" \
-                quiet="TRUE"
-        fi
-    done
-
-    log "... awaiting auction bid acceptance (2 eras + 1 block)"
-    nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='180'
-    await_n_blocks 1
-
     log "... starting nodes"
     TRUSTED_HASH="$(get_chain_latest_block_hash)"
     for NODE_ID in $(seq 1 "$(get_count_of_nodes)")
@@ -311,6 +295,22 @@ function _step_08()
             log "HASH MATCH :: $NODE_ID  :: HASH = $NX_STATE_ROOT_HASH :: N1 HASH = $N1_STATE_ROOT_HASH"
         fi
     done
+
+    log "... submitting auction bids"
+    for NODE_ID in $(seq 1 "$(get_count_of_nodes)")
+    do
+        if [ $(get_node_is_up "$NODE_ID") == false ]; then
+            source "$NCTL/sh/contracts-auction/do_bid.sh" \
+                node="$NODE_ID" \
+                amount="$(get_node_staking_weight "$NODE_ID")" \
+                rate="2" \
+                quiet="TRUE"
+        fi
+    done
+
+    log "... awaiting auction bid acceptance (2 eras + 1 block)"
+    nctl-await-n-eras offset='2' sleep_interval='5.0' timeout='180'
+    await_n_blocks 1
 
     log "Waiting for all nodes to sync to genesis"
     for NODE_ID in $(seq 1 "$(get_count_of_nodes)")

--- a/sh/scenarios/chainspecs/bond_its.chainspec.toml.override
+++ b/sh/scenarios/chainspecs/bond_its.chainspec.toml.override
@@ -2,9 +2,6 @@
 round_seigniorage_rate = [0, 1]
 validator_slots = 6
 
-[highway]
-maximum_round_length = '17seconds'
-
 [deploys]
 block_max_transfer_count = 1
 block_max_approval_count = 250

--- a/sh/scenarios/chainspecs/itst13.chainspec.toml.override
+++ b/sh/scenarios/chainspecs/itst13.chainspec.toml.override
@@ -2,8 +2,5 @@
 era_duration = '210seconds'
 auction_delay = 1
 
-[highway]
-maximum_round_length = '17seconds'
-
 [deploys]
 delete = { cost = 14_000, arguments = [0, 0] }

--- a/sh/scenarios/chainspecs/itst14.chainspec.toml.override
+++ b/sh/scenarios/chainspecs/itst14.chainspec.toml.override
@@ -1,8 +1,5 @@
 [core]
 era_duration = '180seconds'
 
-[highway]
-maximum_round_length = '17seconds'
-
 [deploys]
 delete = { cost = 14_000, arguments = [0, 0] }

--- a/sh/scenarios/chainspecs/itst14_private_chain.chainspec.toml.override
+++ b/sh/scenarios/chainspecs/itst14_private_chain.chainspec.toml.override
@@ -14,8 +14,5 @@ administrators = ["01f137c5b0c252a028cdb3eccf62946c5340837c66a892fc5079a7c1854f0
 compute_rewards = false
 era_duration = '180seconds'
 
-[highway]
-maximum_round_length = '17seconds'
-
 [deploys]
 delete = { cost = 14_000, arguments = [0, 0] }


### PR DESCRIPTION
This PR moves bid adding to after the nodes that are bidding have been synced. This way the nodes will not become validators before they are ready, and not get ejected.