### PR TITLE
Fixes for nightly tests

### DIFF
--- a/sh/scenarios/common/itst.sh
+++ b/sh/scenarios/common/itst.sh
@@ -397,7 +397,7 @@ function verify_transfer_inclusion() {
 
     if [ "$WALKBACK" -gt 0 ]; then
         BLOCK_HEADER=$(echo "$JSON_OUT" | jq '.result.block_with_signatures.block.Version2.header')
-        BLOCK_TRANSFER_HASHES=$(echo "$JSON_OUT" | jq -r '.result.block_with_signatures.block.Version2.body.mint[]')
+        BLOCK_TRANSFER_HASHES=$(echo "$JSON_OUT" | jq -r '.result.block_with_signatures.block.Version2.body.transactions."0"')
         if grep -q "${TRANSFER}" <<< "$BLOCK_TRANSFER_HASHES"; then
             log "Transfer: $TRANSFER found in block!"
         else
@@ -431,7 +431,7 @@ function verify_wasm_inclusion() {
 
     if [ "$WALKBACK" -gt 0 ]; then
         BLOCK_HEADER=$(echo "$JSON_OUT" | jq '.result.block_with_signatures.block.Version2.header')
-        BLOCK_DEPLOY_HASHES=$(echo "$JSON_OUT" | jq -r '.result.block_with_signatures.block.Version2.body.standard[]')
+        BLOCK_DEPLOY_HASHES=$(echo "$JSON_OUT" | jq -r '.result.block_with_signatures.block.Version2.body.transactions')
         if grep -q "${DEPLOY_HASH}" <<< "$BLOCK_DEPLOY_HASHES"; then
             log "DEPLOY: $DEPLOY_HASH found in block!"
         else
@@ -472,7 +472,7 @@ function assert_node_proposed() {
             BLOCK="$(echo "$VERSIONED_BLOCK" | jq '.Version1')"
         fi
 
-        PROPOSER=$(echo "$BLOCK" | jq -r '.body.proposer')
+        PROPOSER=$(echo "$BLOCK" | jq -r '.header.proposer')
 
         if [ "$PROPOSER" == "$PUBLIC_KEY_HEX" ]; then
             log "Node-$NODE_ID created a block!"
@@ -516,7 +516,7 @@ function assert_no_proposal_walkback() {
         else
             BLOCK="$(echo "$VERSIONED_BLOCK" | jq '.Version1')"
         fi
-        PROPOSER=$(echo "$BLOCK" | jq -r '.body.proposer')
+        PROPOSER=$(echo "$BLOCK" | jq -r '.header.proposer')
         if [ "$PROPOSER" = "$PUBLIC_KEY_HEX" ]; then
             log "ERROR: Node proposal found!"
             log "BLOCK HASH $CHECK_HASH: PROPOSER=$PROPOSER, NODE_KEY_HEX=$PUBLIC_KEY_HEX"

--- a/sh/scenarios/sync_upgrade_test.sh
+++ b/sh/scenarios/sync_upgrade_test.sh
@@ -90,6 +90,7 @@ function do_await_network_upgrade() {
             exit 1
         fi
         WAIT_TIME_SEC=$((WAIT_TIME_SEC + 1))
+        CURRENT_ERA=$(get_chain_era || -1)
         sleep 1.0
     done
 }
@@ -99,14 +100,12 @@ function assert_network_upgrade() {
     local COUNT
     local RUNNING_COUNT
     local PROTO=${1}
-    local CONVERTED
     log_step "checking that entire network upgraded to $PROTO"
-    CONVERTED=$(echo $PROTO | sed 's/_/./g')
     STATUS=$(nctl-view-node-status)
-    COUNT=$(grep 'api_version' <<< $STATUS[*] | grep -o "$CONVERTED" | wc -l)
+    COUNT=$(grep '"next_upgrade": null' <<< $(nctl-view-node-status)[*] | wc -l)
     RUNNING_COUNT=$(get_running_node_count)
 
-    if [ ! "$COUNT" = "$RUNNING_COUNT" ]; then
+    if [ "$COUNT" -ne "$RUNNING_COUNT" ]; then
         log "ERROR: Upgrade failed, $COUNT out of $RUNNING_COUNT upgraded successfully."
         exit 1
     fi

--- a/sh/scenarios/sync_upgrade_test.sh
+++ b/sh/scenarios/sync_upgrade_test.sh
@@ -99,9 +99,17 @@ function assert_network_upgrade() {
     local COUNT
     local RUNNING_COUNT
     local PROTO=${1}
+    local CONVERTED
     log_step "checking that entire network upgraded to $PROTO"
+    CONVERTED=$(echo $PROTO | sed 's/_/./g')
+
+    # Give some time for the nodes to upgrade.
     STATUS=$(nctl-view-node-status)
-    COUNT=$(grep '"next_upgrade": null' <<< $(nctl-view-node-status)[*] | wc -l)
+    while [[ "$STATUS" != *"protocol_version"* ]]; do
+        sleep 1.0
+        STATUS=$(nctl-view-node-status)
+    done
+    COUNT=$(grep 'protocol_version' <<< $STATUS[*] | grep -o "$CONVERTED" | wc -l)
     RUNNING_COUNT=$(get_running_node_count)
 
     if [ "$COUNT" -ne "$RUNNING_COUNT" ]; then

--- a/sh/scenarios/sync_upgrade_test.sh
+++ b/sh/scenarios/sync_upgrade_test.sh
@@ -90,7 +90,6 @@ function do_await_network_upgrade() {
             exit 1
         fi
         WAIT_TIME_SEC=$((WAIT_TIME_SEC + 1))
-        CURRENT_ERA=$(get_chain_era || -1)
         sleep 1.0
     done
 }

--- a/sh/utils/queries.sh
+++ b/sh/utils/queries.sh
@@ -95,7 +95,7 @@ function get_node_protocol_version()
     local NODE_ID=${1}
     local TIMEOUT_SEC=${2:-20}
 
-    echo $(_get_from_status_with_retry "$NODE_ID" "$TIMEOUT_SEC" ".api_version") \
+    echo $(_get_from_status_with_retry "$NODE_ID" "$TIMEOUT_SEC" ".protocol_version") \
         | sed -e 's/^"//' -e 's/"$//'
 }
 


### PR DESCRIPTION
- `sh/scenarios/common/itst.sh` contains fixes for modified block schema, it changed recently
- `sh/scenarios/sync_upgrade_test.sh` contains a fix for upgrade check, the upgrade check in the test is incorrect, it looks at the API version of the RPC which is different from the protocol version of the network, we currently do not return the protocol version in the node status which makes it difficult to do an upgrade check, I've replaced it with a check against `next_upgrade` as a short-term fix, we should probably extend the status with protocol version and leverage that once added