### PR TITLE
Fix minor test issues

### DIFF
--- a/sh/scenarios/client.sh
+++ b/sh/scenarios/client.sh
@@ -77,7 +77,7 @@ function main() {
     # 0. Wait for network start up
     do_await_genesis_era_to_complete
     # 1. Check Subcommand Count
-    compare_client_subcommand_count "$(get_client_subcommand_count)" "31"
+    compare_client_subcommand_count "$(get_client_subcommand_count)" "34"
     # 2. Test Each Subcommand Outputs Help
     test_subcommand_help
     # 3. Test generate-completion subcommand: Each SHELL
@@ -1410,7 +1410,7 @@ function compare_client_subcommand_count() {
 
     log_step "Comparing client subcommand count..."
 
-    if [ "$COMP1" = "$COMP2" ]; then
+    if [ "$COMP1" -eq "$COMP2" ]; then
         log "$COMP1 = $COMP2 [expected]"
     else
         log "ERROR: $COMP1 != $COMP2"

--- a/sh/scenarios/regression_4771.sh
+++ b/sh/scenarios/regression_4771.sh
@@ -38,8 +38,6 @@ function main() {
     log "------------------------------------------------------------"
     log "Regression 4771 test finished"
     log "------------------------------------------------------------"
-
-    exit 0
 }
 
 function install_contract() {


### PR DESCRIPTION
- wrong number of client subcommands
- `regression_4771.sh` exits from bash which stops the tests, I don't think we want that