### PR TITLE
undelegate command fixed and updated

### DIFF
--- a/sh/contracts-auction/do_delegate_withdraw.sh
+++ b/sh/contracts-auction/do_delegate_withdraw.sh
@@ -54,7 +54,7 @@ function main()
             --transaction-amount "$AMOUNT" \
             --delegator "$DELEGATOR_ACCOUNT_KEY" \
             --validator "$VALIDATOR_ACCOUNT_KEY" \
-            --gas-price-tolerance 2 \
+            --gas-price-tolerance 1 \
             --standard-payment true \
             | jq '.result.transaction_hash.Version1' \
             | sed -e 's/^"//' -e 's/"$//'

--- a/sh/contracts-auction/do_delegate_withdraw.sh
+++ b/sh/contracts-auction/do_delegate_withdraw.sh
@@ -45,20 +45,20 @@ function main()
     log "... amount = $AMOUNT"
 
     DEPLOY_HASH=$(
-        $PATH_TO_CLIENT put-deploy \
+        $PATH_TO_CLIENT put-transaction undelegate\
             --chain-name "$CHAIN_NAME" \
             --node-address "$NODE_ADDRESS" \
             --payment-amount "$GAS_PAYMENT" \
             --ttl "5minutes" \
             --secret-key "$DELEGATOR_SECRET_KEY" \
-            --session-arg "$(get_cl_arg_u512 'amount' "$AMOUNT")" \
-            --session-arg "$(get_cl_arg_account_key 'delegator' "$DELEGATOR_ACCOUNT_KEY")" \
-            --session-arg "$(get_cl_arg_account_key 'validator' "$VALIDATOR_ACCOUNT_KEY")" \
-            --session-arg "$(get_cl_arg_opt_uref 'unbond_purse' "$DELEGATOR_MAIN_PURSE_UREF")" \
-            --session-path "$PATH_TO_CONTRACT" \
-            | jq '.result.deploy_hash' \
+            --transaction-amount "$AMOUNT" \
+            --delegator "$DELEGATOR_ACCOUNT_KEY" \
+            --validator "$VALIDATOR_ACCOUNT_KEY" \
+            --gas-price-tolerance 2 \
+            --standard-payment true \
+            | jq '.result.transaction_hash.Version1' \
             | sed -e 's/^"//' -e 's/"$//'
-        )
+    )
 
     log "deploy dispatched:"
     log "... deploy hash = $DEPLOY_HASH"


### PR DESCRIPTION
## Description
Brief description of what this PR does and why.
nctl-auction-undelegate command was outdated, it was using old put-deploy command and giving jq parse errors. 

Fixes #(issue)
command script is updated with put-transaction undelegate command and configured. Works fine now.

## Type of change
- [+] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
Describe how you tested your changes:
- Commands run: `nctl-auction-undelegate`
- Network configuration: [e.g., 5 nodes, custom chainspec] : 5 nodes , default chainspec
- Test results: Undelegate command now works fine and updated along with up to date repos.

## Checklist
- [+] My code follows the project's style
- [+] I have tested my changes
- [+] I have updated documentation if needed
- [+] All scripts execute without errors

