### PR TITLE
withdraw command works fine now with implementation of new 'casper-client put-transaction withdraw-bid' command

### DIFF
--- a/sh/contracts-auction/do_bid_withdraw.sh
+++ b/sh/contracts-auction/do_bid_withdraw.sh
@@ -18,12 +18,12 @@ function main()
     local GAS_PAYMENT
     local NODE_ADDRESS
     local PATH_TO_CLIENT
-    local PATH_TO_CONTRACT
     local BIDDER_SECRET_KEY
     local BIDDER_ACCOUNT_KEY
-    local BIDDER_MAIN_PURSE_UREF
-    local DEPLOY_RESULT
-
+    local TRANSACTION_RESULT
+    
+    log "default amount , $AMOUNT"
+    
     log "getting chain name"
     CHAIN_NAME=$(get_chain_name)
     log "getting gas payment"
@@ -32,53 +32,47 @@ function main()
     NODE_ADDRESS=$(get_node_address_rpc)
     log "getting path to client"
     PATH_TO_CLIENT=$(get_path_to_client)
-    log "getting path to contract"
-    PATH_TO_CONTRACT=$(get_path_to_contract "auction/withdraw_bid.wasm")
 
     log "getting secret key"
     BIDDER_SECRET_KEY=$(get_path_to_secret_key "$NCTL_ACCOUNT_TYPE_NODE" "$BIDDER_ID")
     log "getting account key"
     BIDDER_ACCOUNT_KEY=$(get_account_key "$NCTL_ACCOUNT_TYPE_NODE" "$BIDDER_ID" | tr '[:upper:]' '[:lower:]')
-    log "getting main purse uref"
-    BIDDER_MAIN_PURSE_UREF=$(get_main_purse_uref "$BIDDER_ACCOUNT_KEY" | tr '[:upper:]' '[:lower:]')
 
     if [ "$QUIET" != "TRUE" ]; then
-        log "dispatching deploy -> withdraw_bid.wasm"
+        log "dispatching transaction"
         log "... chain = $CHAIN_NAME"
         log "... dispatch node = $NODE_ADDRESS"
-        log "... contract = $PATH_TO_CONTRACT"
         log "... bidder id = $BIDDER_ID"
         log "... bidder account key = $BIDDER_ACCOUNT_KEY"
         log "... bidder secret key = $BIDDER_SECRET_KEY"
-        log "... bidder main purse uref = $BIDDER_MAIN_PURSE_UREF"
         log "... withdrawal amount = $AMOUNT"
     fi
 
-    log "... sending deploy"
-    DEPLOY_RESULT=$($PATH_TO_CLIENT put-deploy \
+    log "... sending transaction"
+    TRANSACTION_RESULT=$($PATH_TO_CLIENT put-transaction withdraw-bid \
                                  --chain-name "$CHAIN_NAME" \
                                  --node-address "$NODE_ADDRESS" \
                                  --payment-amount "$GAS_PAYMENT" \
                                  --ttl "5min" \
                                  --secret-key "$BIDDER_SECRET_KEY" \
-                                 --session-arg "$(get_cl_arg_account_key 'public_key' "$BIDDER_ACCOUNT_KEY")" \
-                                 --session-arg "$(get_cl_arg_u512 'amount' "$AMOUNT")" \
-                                 --session-arg "$(get_cl_arg_opt_uref 'unbond_purse' "$BIDDER_MAIN_PURSE_UREF")" \
-                                 --session-path "$PATH_TO_CONTRACT")
-    if [ -z "$DEPLOY_RESULT" ]; then
-        log "failed to get deploy result"
+                                 --gas-price-tolerance 1 \
+                                 --standard-payment true \
+                                 --public-key "$BIDDER_ACCOUNT_KEY" \
+                                 --transaction-amount "$AMOUNT" )
+    if [ -z "$TRANSACTION_RESULT" ]; then
+        log "failed to get transaction result"
         log "... node address: $NODE_ADDRESS"
         exit 1
     else
-        echo "$DEPLOY_RESULT"
+        echo "$TRANSACTION_RESULT"
     fi
 
-    log "... getting deploy hash"
-    DEPLOY_HASH=$(echo $DEPLOY_RESULT | jq -r '.result.deploy_hash')
+    log "... getting transaction hash"
+    TRANSACTION_HASH=$(echo $TRANSACTION_RESULT | jq -r '.result.transaction_hash.Version1')
 
     if [ "$QUIET" != "TRUE" ]; then
-        log "deploy dispatched:"
-        log "... deploy hash = $DEPLOY_HASH"
+        log "transation dispatched:"
+        log "... transaction hash = $TRANSACTION_HASH"
     fi
 }
 
@@ -101,4 +95,4 @@ do
 done
 
 main "${NODE_ID:-1}" \
-     "${AMOUNT:-$(get_node_staking_weight "${NODE_ID:-1}")}"
+     "${AMOUNT:-$(get_node_default_bid_withdraw_amount "${NODE_ID:-1}")}"

--- a/sh/utils/constants.sh
+++ b/sh/utils/constants.sh
@@ -49,6 +49,10 @@ export NCTL_CONTRACTS_CLIENT_TRANSFERS=(
 # Default amount used when delegating.
 export NCTL_DEFAULT_AUCTION_DELEGATE_AMOUNT=1000000000   # (1e9)
 
+# Default amount to withdraw
+export NCTL_DEFAULT_AUCTION_BID_WITHDRAW_AMOUNT=1000000000   # (1e9)
+
+
 # Default era offset to apply when activating an upgrade.
 export NCTL_DEFAULT_ERA_ACTIVATION_OFFSET=2
 

--- a/sh/utils/infra.sh
+++ b/sh/utils/infra.sh
@@ -266,6 +266,19 @@ function get_node_staking_weight()
 }
 
 #######################################
+# Calculates a node's default withdraw amount.
+# Arguments:
+#   Node ordinal identifier.
+#######################################
+function get_node_default_bid_withdraw_amount()
+{
+    local NODE_ID=${1}
+
+    echo $((NCTL_DEFAULT_AUCTION_BID_WITHDRAW_AMOUNT + NODE_ID))
+}
+
+
+#######################################
 # Returns set of nodes within a process group.
 # Arguments:
 #   Process group identifier.


### PR DESCRIPTION
## Description
`nctl-auction-withdraw` command was giving parse errors and was implemented with deprecated put-deploy implementation. Its updated with the implementation of new put-transaction command of casper-client. New constant added for default withdraw-bid amount and new function defined in infra.sh to calculate it. Redundant variables removed.

Fixes #32  

## Type of change
- [+] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
Describe how you tested your changes:
- Commands run: `nctl-auction-withdraw`
- Network configuration: 10 nodes (6 active , 4 inactive) default chainspec of local casper-node.

- Test results:
Command runs without any warning or error and gives the transaction_hash of the successful transaction. Withdraw process is done successfully.

## Checklist
- [+] My code follows the project's style
- [+] I have tested my changes
- [+] I have updated documentation if needed
- [+] All scripts execute without errors

