### PR TITLE
activate-bid commands implementation is now up to date with latest casper-node and casper-client.

### DIFF
--- a/sh/contracts-auction/do_bid_activate.sh
+++ b/sh/contracts-auction/do_bid_activate.sh
@@ -25,13 +25,12 @@ function main()
     GAS_PAYMENT=${GAS_PAYMENT:-$NCTL_DEFAULT_GAS_PAYMENT}
     NODE_ADDRESS=$(get_node_address_rpc)
     PATH_TO_CLIENT=$(get_path_to_client)
-    PATH_TO_CONTRACT=$(get_path_to_contract "auction/activate_bid.wasm")
 
     VALIDATOR_ACCOUNT_KEY=$(get_account_key "$NCTL_ACCOUNT_TYPE_NODE" "$VALIDATOR_ID")
     VALIDATOR_SECRET_KEY=$(get_path_to_secret_key "$NCTL_ACCOUNT_TYPE_NODE" "$VALIDATOR_ID")
 
     if [ "$QUIET" != "TRUE" ]; then
-        log "dispatching deploy -> activate_bid.wasm"
+        log "dispatching transaction"
         log "... chain = $CHAIN_NAME"
         log "... dispatch node = $NODE_ADDRESS"
         log "... contract = $PATH_TO_CONTRACT"
@@ -40,22 +39,23 @@ function main()
         log "... validator secret key = $VALIDATOR_SECRET_KEY"
     fi
 
-    DEPLOY_HASH=$(
-        $PATH_TO_CLIENT put-deploy \
+    TRANSACTION_HASH=$(
+        $PATH_TO_CLIENT put-transaction activate-bid \
             --chain-name "$CHAIN_NAME" \
             --node-address "$NODE_ADDRESS" \
             --payment-amount "$GAS_PAYMENT" \
             --ttl "5minutes" \
             --secret-key "$VALIDATOR_SECRET_KEY" \
-            --session-arg "$(get_cl_arg_account_key 'validator_public_key' "$VALIDATOR_ACCOUNT_KEY")" \
-            --session-path "$PATH_TO_CONTRACT" \
-            | jq '.result.deploy_hash' \
+            --validator "$VALIDATOR_ACCOUNT_KEY" \
+            --gas-price-tolerance 1 \
+            --standard-payment true \
+            | jq '.result.transaction_hash.Version1' \
             | sed -e 's/^"//' -e 's/"$//'
         )
 
     if [ "$QUIET" != "TRUE" ]; then
-        log "deploy dispatched:"
-        log "... deploy hash = $DEPLOY_HASH"
+        log "transaction dispatched:"
+        log "... transaction hash = $TRANSACTION_HASH"
     fi
 }
 


### PR DESCRIPTION
## Description
Old implementation of the  `nctl-auction-activate` command was using deprecated put-deploy command was giving parse error and not giving proper output. put-deploy replaced with put-transaction command and configured. Redundant variables removed.

Fixes #31  

## Type of change
- [+] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
Describe how you tested your changes:
- Commands run: `nctl-auction-activate`
- Network configuration: 10 nodes (6 active , 4 inactive) default chainspec of local casper-node.
- Test results: Command now runs without any issues, makes successful transaction and gives proper output including the transaction hash.

## Checklist
- [+] My code follows the project's style
- [+] I have tested my changes
- [+] I have updated documentation if needed
- [+] All scripts execute without errors

